### PR TITLE
Reduce github api calls

### DIFF
--- a/lib/prpr/action/lgtm/comment.rb
+++ b/lib/prpr/action/lgtm/comment.rb
@@ -71,7 +71,7 @@ module Prpr
         end
 
         def labels
-          github.labels_for_issue(repository, pull_request_number)
+          event.pull_request.labels
         end
 
         def label(name)


### PR DESCRIPTION
I want to reduce GitHub API calls.

`prpr-lgtm` fetches labels via GitHub API.
But labels are contained in Webhook Payloads.